### PR TITLE
Send multipart data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ _testmain.go
 *.exe
 *.test
 *.prof
+bin

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# libclick [![Build Status](https://api.travis-ci.org/Altinity/libclick-go.svg?branch=master)](https://github.com/Altinity/libclick-go)
+# libtb
 
-Go library for sending events to [ClickHouse](https://clickhouse.yandex). This is a fork of [libhoney-go](https://godoc.org/github.com/honeycombio/libhoney-go) libarary.
+Go library for sending events to [Tinybird](https://www.tinybird.co/). This is a fork of [libhoney-go](https://godoc.org/github.com/honeycombio/libhoney-go) library.
 
 ## Installation:
 
 ```
-go get -v github.com/Altinity/libclick-go
+go get -v github.com/ygnuss/libtb-go
 ```
 
 ## Documentation

--- a/doc.go
+++ b/doc.go
@@ -1,9 +1,9 @@
 /*
-Package libtb is a client library for sending data to ClickHouse DB Server
+Package libtb is a client library for sending data to Tinybird Server
 
 Summary
 
-libtb aims to make it as easy as possible to create events and send them into ClickHouse.
+libtb aims to make it as easy as possible to create events and send them to Tinybird.
 
 */
 package libtb

--- a/doc.go
+++ b/doc.go
@@ -1,9 +1,9 @@
 /*
-Package libclick is a client library for sending data to ClickHouse DB Server
+Package libtb is a client library for sending data to ClickHouse DB Server
 
 Summary
 
-libclick aims to make it as easy as possible to create events and send them into ClickHouse.
+libtb aims to make it as easy as possible to create events and send them into ClickHouse.
 
 */
-package libclick
+package libtb

--- a/examples/read_json_log.go
+++ b/examples/read_json_log.go
@@ -9,7 +9,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/Altinity/libclick-go"
+	"github.com/ygnuss/libtb-go"
 )
 
 // This example reads JSON blobs from a file and sends them as Honeycomb events.
@@ -30,21 +30,21 @@ var jsonFilePaths = []string{"./example1.json", "./example2.json"}
 func main() {
 
 	// basic initialization
-	libhConf := libclick.Config{
+	libhConf := libtb.Config{
 		WriteKey: honeyFakeWritekey,
 		Dataset:  honeyDataset,
 	}
-	libclick.Init(libhConf)
-	defer libclick.Close()
-	go readResponses(libclick.Responses())
+	libtb.Init(libhConf)
+	defer libtb.Close()
+	go readResponses(libtb.Responses())
 
 	// We want every event to include the number of currently running goroutines
 	// and the version number of this app. The goroutines is contrived for this
 	// example, but is useful in larger apps. Adding the version number to the
 	// global scope means every event sent will include this field.
-	libclick.AddDynamicField("num_goroutines",
+	libtb.AddDynamicField("num_goroutines",
 		func() interface{} { return runtime.NumGoroutine() })
-	libclick.AddField("read_json_log_version", version)
+	libtb.AddField("read_json_log_version", version)
 
 	// go through each json file and parse it.
 	for _, fileName := range jsonFilePaths {
@@ -59,7 +59,7 @@ func main() {
 		// processed. This builder will be passed in to processLine so all events
 		// created within that function will have the information about the file
 		// and line being processed.
-		perFileBulider := libclick.NewBuilder()
+		perFileBulider := libtb.NewBuilder()
 		perFileBulider.AddField("json_file_name", fileName)
 
 		scanner := bufio.NewScanner(fh)
@@ -75,7 +75,7 @@ func main() {
 	fmt.Println("All done! Go check Honeycomb https://ui.honeycomb.io/ to see your data.")
 }
 
-func readResponses(responses chan libclick.Response) {
+func readResponses(responses chan libtb.Response) {
 	for r := range responses {
 		if r.StatusCode >= 200 && r.StatusCode < 300 {
 			id := r.Metadata.(string)
@@ -87,7 +87,7 @@ func readResponses(responses chan libclick.Response) {
 	}
 }
 
-func processLine(line string, builder *libclick.Builder) {
+func processLine(line string, builder *libtb.Builder) {
 
 	// Create the event that this line will fill. because we're creating it from
 	// the Builder, it will already have a field containing the name and line

--- a/libtb.go
+++ b/libtb.go
@@ -139,8 +139,7 @@ func VerifyApiHost(config Config) error {
 		return fmt.Errorf("Error parsing API URL: %s", err)
 	}
 
-	//req, err := http.NewRequest("GET", strings.Join([]string{u.String(), "v0/datasources/nginx_1?token=p.eyJ1IjogIjMzNjU3ODViLTRlNTYtNDY3MS1iMGUzLThjNjUzOTJiODhlYSIsICJpZCI6ICJiOTMwZjMyMi00MGYyLTQ5MDYtYWYxYi1jMjNiMWE2MmJkNWUifQ.AjCuIPMjMzzp_zprh_8ha2ALe4CMjOBOQOGyQALde-M"}, ""), nil)
-	req, err := http.NewRequest("GET", strings.Join([]string{u.String(), "v0/datasources/nginx_1?token=", config.WriteKey}, ""), nil)
+	req, err := http.NewRequest("GET", strings.Join([]string{u.String(), "v0/datasources/", config.Dataset, "?token=", config.WriteKey}, ""), nil)
 	if err != nil {
 		return err
 	}

--- a/libtb.go
+++ b/libtb.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the Apache License 2.0
 // license that can be found in the LICENSE file.
 
-package libclick
+package libtb
 
 import (
 	"bytes"
@@ -64,8 +64,8 @@ var (
 )
 
 // UserAgentAddition is a variable set at compile time via -ldflags to allow you
-// to augment the "User-Agent" header that libclick sends along with each event.
-// The default User-Agent is "libclick-go/<version>". If you set this variable, its
+// to augment the "User-Agent" header that libtb sends along with each event.
+// The default User-Agent is "libtb-go/<version>". If you set this variable, its
 // contents will be appended to the User-Agent string, separated by a space. The
 // expected format is product-name/version, eg "myapp/1.0"
 var UserAgentAddition string
@@ -74,13 +74,13 @@ var UserAgentAddition string
 type Config struct {
 
 	// WriteKey is the Honeycomb authentication token. If it is specified during
-	// libclick initialization, it will be used as the default write key for all
+	// libtb initialization, it will be used as the default write key for all
 	// events. If absent, write key must be explicitly set on a builder or
 	// event. Find your team write key at https://ui.honeycomb.io/account
 	WriteKey string
 
 	// Dataset is the name of the Honeycomb dataset to which to send these events.
-	// If it is specified during libclick initialization, it will be used as the
+	// If it is specified during libtb initialization, it will be used as the
 	// default dataset for all events. If absent, dataset must be explicitly set
 	// on a builder or event.
 	Dataset string
@@ -96,12 +96,12 @@ type Config struct {
 
 	// TODO add logger in an agnostic way
 
-	// BlockOnSend determines if libclick should block or drop packets that exceed
+	// BlockOnSend determines if libtb should block or drop packets that exceed
 	// the size of the send channel (set by PendingWorkCapacity). Defaults to
 	// False - events overflowing the send channel will be dropped.
 	BlockOnSend bool
 
-	// BlockOnResponse determines if libclick should block trying to hand
+	// BlockOnResponse determines if libtb should block trying to hand
 	// responses back to the caller. If this is true and there is nothing reading
 	// from the Responses channel, it will fill up and prevent events from being
 	// sent to Honeycomb. Defaults to False - if you don't read from the Responses
@@ -137,7 +137,7 @@ func VerifyApiHost(config Config) error {
 	if err != nil {
 		return fmt.Errorf("Error parsing API URL: %s", err)
 	}
-	req, err := http.NewRequest("GET", strings.Join([]string{u.String(), "?query=SELECT+'Ok.'"}, "") , nil)
+	req, err := http.NewRequest("GET", strings.Join([]string{u.String(), "?query=SELECT+'Ok.'"}, ""), nil)
 	if err != nil {
 		return err
 	}
@@ -200,11 +200,11 @@ func (e *Event) MarshalJSON() ([]byte, error) {
 		sampleRate = 0
 	}
 
-    if !e.Timestamp.IsZero() {
-        e.data["_date"] = e.Timestamp.Format(time.RFC3339)[0:10]
-        e.data["_time"] = e.Timestamp.Format(time.RFC3339)[0:19]
-        e.data["_ms"] = e.Timestamp.Nanosecond() / 1000
-    }
+	if !e.Timestamp.IsZero() {
+		e.data["_date"] = e.Timestamp.Format(time.RFC3339)[0:10]
+		e.data["_time"] = e.Timestamp.Format(time.RFC3339)[0:19]
+		e.data["_ms"] = e.Timestamp.Nanosecond() / 1000
+	}
 
 	return json.Marshal(e.data) /*struct {
 		Data       marshallableMap `json:"data"`
@@ -348,7 +348,7 @@ func Init(config Config) error {
 		return err
 	}
 
-	sd, _ = statsd.New(statsd.Prefix("libclick"))
+	sd, _ = statsd.New(statsd.Prefix("libtb"))
 	responses = make(chan Response, config.PendingWorkCapacity*2)
 
 	defaultBuilder = &Builder{

--- a/libtb.go
+++ b/libtb.go
@@ -28,8 +28,9 @@ func init() {
 
 const (
 	defaultSampleRate = 1
-	defaultAPIHost    = "http://localhost:8123/"
-	version           = "1.4.0"
+	// defaultAPIHost    = "http://localhost:8123/"
+	defaultAPIHost = "http://localhost:8001/"
+	version        = "1.4.0"
 
 	// DefaultMaxBatchSize how many events to collect in a batch
 	DefaultMaxBatchSize = 1000000
@@ -137,7 +138,7 @@ func VerifyApiHost(config Config) error {
 	if err != nil {
 		return fmt.Errorf("Error parsing API URL: %s", err)
 	}
-	req, err := http.NewRequest("GET", strings.Join([]string{u.String(), "?query=SELECT+'Ok.'"}, ""), nil)
+	req, err := http.NewRequest("GET", strings.Join([]string{u.String(), "v0/datasources/nginx_1?token=p.eyJ1IjogIjMzNjU3ODViLTRlNTYtNDY3MS1iMGUzLThjNjUzOTJiODhlYSIsICJpZCI6ICJiOTMwZjMyMi00MGYyLTQ5MDYtYWYxYi1jMjNiMWE2MmJkNWUifQ.AjCuIPMjMzzp_zprh_8ha2ALe4CMjOBOQOGyQALde-M"}, ""), nil)
 	if err != nil {
 		return err
 	}
@@ -149,11 +150,11 @@ func VerifyApiHost(config Config) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusUnauthorized {
-		return errors.New("ClickHouse server rejected authentication")
+		return errors.New("Tinybird server rejected authentication")
 	}
 	if resp.StatusCode != http.StatusOK {
 		body, _ := ioutil.ReadAll(resp.Body)
-		return fmt.Errorf(`Abnormal non-200 response from ClickHouse server: %d
+		return fmt.Errorf(`Abnormal non-200 response from Tinybird server: %d
 Response body: %s`, resp.StatusCode, string(body))
 	}
 

--- a/response.go
+++ b/response.go
@@ -1,4 +1,4 @@
-package libclick
+package libtb
 
 import (
 	"encoding/json"

--- a/transmission.go
+++ b/transmission.go
@@ -21,7 +21,6 @@ import (
 	"net/url"
 	"os"
 	"path"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -315,7 +314,13 @@ func (b *batchAgg) encodeBatch(events []*Event) ([]byte, int) {
 		}
 		first = false
 		evByt, err := json.Marshal(ev)
-		var escEventContent string = strconv.Quote(fmt.Sprintf("%s", evByt))
+		// Escape json to be processed as CSV with a String.
+		// We need to change " by "" and quote the whole string
+		// Example: {"field_a": "value_a"} --> "{""field_a"": ""value_a""}""
+		var escQuotes string = strings.Replace(fmt.Sprintf("%s", evByt), "\"", "\"\"", -1)
+		var escEventContent string = fmt.Sprintf("\"%s\"", escQuotes)
+
+		//var escEventContent string = strconv.Quote(fmt.Sprintf("%s", evByt))
 
 		fmt.Printf("EVENTO: %s\n", escEventContent)
 

--- a/transmission.go
+++ b/transmission.go
@@ -212,7 +212,7 @@ func (b *batchAgg) fireBatch(events []*Event) {
 	q.Add("dialect_delimiter", "|")
 	req.URL.RawQuery = q.Encode()
 
-	// req.Header.Set("Content-Type", "application/json")
+	//req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Content-Type", "application/csv")
 	if gzipped {
 		req.Header.Set("Content-Encoding", "gzip")
@@ -220,8 +220,8 @@ func (b *batchAgg) fireBatch(events []*Event) {
 	req.Header.Set("User-Agent", userAgent)
 	req.Header.Add("X-Honeycomb-Team", writeKey)
 
-	// var bearer = "Bearer " + writeKey
-	var bearer = "Bearer " + "p.eyJ1IjogIjMzNjU3ODViLTRlNTYtNDY3MS1iMGUzLThjNjUzOTJiODhlYSIsICJpZCI6ICJiOTMwZjMyMi00MGYyLTQ5MDYtYWYxYi1jMjNiMWE2MmJkNWUifQ.AjCuIPMjMzzp_zprh_8ha2ALe4CMjOBOQOGyQALde-M"
+	var bearer = "Bearer " + writeKey
+	//var bearer = "Bearer " + "p.eyJ1IjogIjMzNjU3ODViLTRlNTYtNDY3MS1iMGUzLThjNjUzOTJiODhlYSIsICJpZCI6ICJiOTMwZjMyMi00MGYyLTQ5MDYtYWYxYi1jMjNiMWE2MmJkNWUifQ.AjCuIPMjMzzp_zprh_8ha2ALe4CMjOBOQOGyQALde-M"
 	req.Header.Add("Authorization", bearer)
 
 	// send off batch!
@@ -382,7 +382,9 @@ func (w *WriterOutput) Stop() error  { return nil }
 func (w *WriterOutput) Add(ev *Event) {
 	w.Lock()
 	defer w.Unlock()
-	m, _ := ev.MarshalCSV()
+	//m, _ := ev.MarshalCSV()
+	m, _ := ev.MarshalJSON()
+
 	m = append(m, '\n')
 	if w.W == nil {
 		w.W = os.Stdout

--- a/transmission.go
+++ b/transmission.go
@@ -164,6 +164,8 @@ func (b *batchAgg) fireBatch(events []*Event) {
 	if numEncoded == 0 {
 		return
 	}
+
+	fmt.Printf("Sending batch with %d events", numEncoded)
 	// get some attributes common to this entire batch up front
 	apiHost := events[0].APIHost
 	writeKey := events[0].WriteKey
@@ -313,7 +315,7 @@ func (b *batchAgg) encodeBatch(events []*Event) ([]byte, int) {
 		var escQuotes string = strings.Replace(fmt.Sprintf("%s", evByt), "\"", "\"\"", -1)
 		var escEventContent string = fmt.Sprintf("\"%s\"", escQuotes)
 
-		fmt.Printf("EVENT: %s\n", escEventContent)
+		//fmt.Printf("EVENT: %s\n", escEventContent)
 
 		if err != nil {
 			b.enqueueResponse(Response{

--- a/transmission.go
+++ b/transmission.go
@@ -1,4 +1,4 @@
-package libclick
+package libtb
 
 // txClient handles the transmission of events to Honeycomb.
 //
@@ -50,7 +50,7 @@ type txDefaultClient struct {
 	muster muster.Client
 }
 
-func (t *txDefaultClient) Start() error { 
+func (t *txDefaultClient) Start() error {
 	t.muster.MaxBatchSize = t.maxBatchSize
 	t.muster.BatchTimeout = t.batchTimeout
 	t.muster.MaxConcurrentBatches = t.maxConcurrentBatches
@@ -171,7 +171,7 @@ func (b *batchAgg) fireBatch(events []*Event) {
 	dataset := events[0].Dataset
 
 	// sigh. dislike
-	userAgent := fmt.Sprintf("libclick-go/%s", version)
+	userAgent := fmt.Sprintf("libtb-go/%s", version)
 	if UserAgentAddition != "" {
 		userAgent = fmt.Sprintf("%s %s", userAgent, strings.TrimSpace(UserAgentAddition))
 	}

--- a/transmission.go
+++ b/transmission.go
@@ -382,7 +382,7 @@ func (w *WriterOutput) Stop() error  { return nil }
 func (w *WriterOutput) Add(ev *Event) {
 	w.Lock()
 	defer w.Unlock()
-	m, _ := ev.MarshalJSON()
+	m, _ := ev.MarshalCSV()
 	m = append(m, '\n')
 	if w.W == nil {
 		w.W = os.Stdout


### PR DESCRIPTION
We have changed the POST request to use a multipart form instead of sending everything in the body. The reason is we reach the limits. With multipart we can send up to 10GB. More info about the limits [here](https://docs.tinybird.co/api-reference/api-reference.html#limits-title).